### PR TITLE
Add seeders for default users, artists, albums, songs, posts, likes, playlists, playlist songs, playback history, comments, and followed playlists

### DIFF
--- a/app/Http/Controllers/PlaybackHistoryController.php
+++ b/app/Http/Controllers/PlaybackHistoryController.php
@@ -17,8 +17,7 @@ class PlaybackHistoryController extends Controller
     {
         //Validar los datos
         $validator = Validator::make($request->all(), [
-            'song_id' => 'required|exists:songs,id',
-            'play_date' => 'required|date'
+            'song_id' => 'required|exists:songs,id'
         ]);
 
         if ($validator->fails()) {
@@ -29,7 +28,6 @@ class PlaybackHistoryController extends Controller
         $playbackHistory = new PlaybackHistory();
         $playbackHistory->user_id = $request->user()->id;
         $playbackHistory->song_id = $request->song_id;
-        $playbackHistory->play_date = $request->play_date;
         $playbackHistory->save();
 
         return response()->json($playbackHistory, 201);
@@ -42,7 +40,7 @@ class PlaybackHistoryController extends Controller
     {
         //Mostrar historial de reproducciones de la mas reciente a la mas antigua
         $playbackHistory = PlaybackHistory::where('user_id', $request->user()->id)
-            ->orderBy('play_date', 'desc')
+            ->orderBy('created_at', 'desc')
             ->get();
 
         return response()->json($playbackHistory, 200);

--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -41,7 +41,6 @@ class PlaylistController extends Controller
         $validator = Validator::make($request->all(), [
             'name' => 'required',
             'user_id' => 'required',
-            'release_date' => 'required',
             'description' => 'required',
             'privacy' => 'required',
             'image' => 'required',
@@ -68,7 +67,6 @@ class PlaylistController extends Controller
         $playlist = new Playlist();
         $playlist->name = $request->name;
         $playlist->user_id = $request->user_id;
-        $playlist->release_date = $request->release_date;
         $playlist->description = $request->description;
         $playlist->privacy = $request->privacy;
         $playlist->image = $request->image;

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -38,7 +38,6 @@ class PostController extends Controller
             $validator = Validator::make($request->all(), [
                 'user_id' => 'required|exists:users,id',
                 'content' => 'required|string',
-                'publishing_date' => 'required|date',
                 'image' => 'nullable|string',
                 'song_id' => 'required|exists:songs,id',
                 'is_active' => 'required|boolean',
@@ -104,7 +103,6 @@ class PostController extends Controller
             $validator = Validator::make($request->all(), [
                 'user_id' => 'exists:users,id',
                 'content' => 'string',
-                'publishing_date' => 'date',
                 'image' => 'nullable|string',
                 'song_id' => 'exists:songs,id',
                 'is_active' => 'boolean',

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -107,7 +107,6 @@ class TestController extends Controller
         $playlistSong = new PlaylistSong();
         $playlistSong->playlist_id = $playlist->id; // Usar un ID existente de la tabla `playlists`
         $playlistSong->song_id = $song->id; // Usar un ID existente de la tabla `songs`
-        $playlistSong->date_added = now()->toDateString();
         $playlistSong->save();
 
         // Crear una lista de reproducción compartida

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -69,7 +69,7 @@ class TestController extends Controller
         $song->title = 'Hit Song';
         $song->artist_id = $artist->id; // Usar un ID existente de la tabla `artists`
         $song->album_id = $album->id; // Usar un ID existente de la tabla `albums`
-        $song->time = '03:30:00';
+        $song->time = '00:03:30';
         $song->genre = 'Pop';
         $song->url_song = 'https://example.com/hit_song.mp3';
         $song->save();
@@ -78,7 +78,6 @@ class TestController extends Controller
         $post = new Post();
         $post->user_id = '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3'; // Usar un UUID existente de la tabla `users`
         $post->content = 'Check out my new song!';
-        $post->publishing_date = now()->toDateString();
         $post->image = 'post_image.png';
         $post->song_id = $song->id; // Usar un ID existente de la tabla `songs`
         $post->save();

--- a/app/Http/Controllers/TestController.php
+++ b/app/Http/Controllers/TestController.php
@@ -98,7 +98,6 @@ class TestController extends Controller
         $playlist = new Playlist();
         $playlist->name = 'My Favorite Songs';
         $playlist->user_id = '8f6eea1e-9011-40ec-8ae4-19916127672b'; // Usar un UUID existente de la tabla `users`
-        $playlist->release_date = now()->toDateString();
         $playlist->description = 'A collection of my favorite songs.';
         $playlist->privacy = 'shared';
         $playlist->image = 'playlist_image.png';
@@ -121,7 +120,6 @@ class TestController extends Controller
         $playbackHistory = new PlaybackHistory();
         $playbackHistory->user_id = '8f6eea1e-9011-40ec-8ae4-19916127672b'; // Usar un UUID existente de la tabla `users`
         $playbackHistory->song_id = $song->id; // Usar un ID existente de la tabla `songs`
-        $playbackHistory->play_date = now();
         $playbackHistory->save();
 
         // Crear un nuevo comentario
@@ -129,14 +127,12 @@ class TestController extends Controller
         $comment->user_id = '8f6eea1e-9011-40ec-8ae4-19916127672b'; // Usar un UUID existente de la tabla `users`
         $comment->post_id = $post->id; // Usar un ID existente de la tabla `posts`
         $comment->content = 'Great post!';
-        $comment->publication_date = now();
         $comment->save();
 
         // Crear un nuevo seguidor a una lista
         $followedPlaylist = new FollowedPlaylist();
         $followedPlaylist->user_id = '8f6eea1e-9011-40ec-8ae4-19916127672b'; // Usar un UUID existente de la tabla `users`
         $followedPlaylist->playlist_id = $playlist->id; // Usar un ID existente de la tabla `playlists`
-        $followedPlaylist->follow_date = now();
         $followedPlaylist->save();
 
         return response()->json([

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -11,7 +11,7 @@ class Comment extends Model
 
     protected $primaryKey = 'id'; // Clave primaria (autoincremental)
     public $incrementing = true; // Es un campo autoincremental
-    protected $fillable = ['user_id', 'post_id', 'content', 'publication_date', 'is_active']; // Atributos que pueden ser asignados en masa
+    protected $fillable = ['user_id', 'post_id', 'content', 'is_active']; // Atributos que pueden ser asignados en masa
 
     /**
      * Relación con el modelo User.

--- a/app/Models/FollowedPlaylist.php
+++ b/app/Models/FollowedPlaylist.php
@@ -9,7 +9,7 @@ class FollowedPlaylist extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'playlist_id', 'follow_date'];
+    protected $fillable = ['user_id', 'playlist_id'];
 
     /**
      * Relación con el modelo User.

--- a/app/Models/PlaybackHistory.php
+++ b/app/Models/PlaybackHistory.php
@@ -11,7 +11,7 @@ class PlaybackHistory extends Model
 
     protected $primaryKey = 'id'; // Clave primaria (autoincremental)
     public $incrementing = true; // Es un campo autoincremental
-    protected $fillable = ['user_id', 'song_id', 'play_date', 'is_active']; // Atributos que pueden ser asignados en masa
+    protected $fillable = ['user_id', 'song_id', 'is_active']; // Atributos que pueden ser asignados en masa
 
     /**
      * Relación con el modelo User.

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -24,12 +24,11 @@ class Playlist extends Model
 
     /**
      * Relación con el modelo Song.
-     * Una playlist puede tener muchas canciones a través de la tabla pivot SongInPlaylist.
+     * Una playlist puede tener muchas canciones a través de la tabla pivot PlaylistSong.
      */
     public function songs()
     {
-        return $this->belongsToMany(Song::class, 'song_in_playlists', 'playlist_id', 'song_id')
-            ->withPivot('date_added');
+        return $this->belongsToMany(Song::class, 'playlist_songs', 'playlist_id', 'song_id');
     }
 
     /**

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -11,7 +11,7 @@ class Playlist extends Model
 
     protected $primaryKey = 'id'; // Clave primaria (autoincremental)
     public $incrementing = true; // Es un campo autoincremental
-    protected $fillable = ['name', 'user_id', 'release_date', 'description', 'privacy', 'image', 'is_active']; // Atributos que pueden ser asignados en masa
+    protected $fillable = ['name', 'user_id', 'description', 'privacy', 'image', 'is_active']; // Atributos que pueden ser asignados en masa
 
     /**
      * Relación con el modelo User.

--- a/app/Models/PlaylistSong.php
+++ b/app/Models/PlaylistSong.php
@@ -11,7 +11,7 @@ class PlaylistSong extends Model
 
     public $incrementing = false; // No tiene un ID propio, ya que la clave es compuesta
     protected $primaryKey = ['playlist_id', 'song_id']; // Clave primaria compuesta
-    protected $fillable = ['playlist_id', 'song_id', 'date_added', 'is_active']; // Atributos que pueden ser asignados en masa
+    protected $fillable = ['playlist_id', 'song_id', 'is_active']; // Atributos que pueden ser asignados en masa
 
     /**
      * Relación con el modelo Playlist.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -11,7 +11,7 @@ class Post extends Model
 
     protected $primaryKey = 'id'; // Clave primaria (autoincremental)
     public $incrementing = true; // Es un campo autoincremental
-    protected $fillable = ['user_id', 'content', 'publishing_date', 'image', 'song_id', 'is_active']; // Atributos que pueden ser asignados en masa
+    protected $fillable = ['user_id', 'content', 'image', 'song_id', 'is_active']; // Atributos que pueden ser asignados en masa
 
     /**
      * Relación con el modelo User.

--- a/database/migrations/2024_09_06_180505_create_posts_table.php
+++ b/database/migrations/2024_09_06_180505_create_posts_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id();
             $table->foreignUuid('user_id')->constrained('users')->onDelete('cascade');
             $table->text('content');
-            $table->date('publishing_date');
             $table->string('image')->nullable();
             $table->foreignId('song_id')->constrained('songs')->onDelete('cascade');
             $table->boolean('is_active')->default(true);

--- a/database/migrations/2024_09_06_180510_create_playlists_table.php
+++ b/database/migrations/2024_09_06_180510_create_playlists_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->foreignUuid('user_id')->constrained('users')->onDelete('cascade');
-            $table->date('release_date');
             $table->text('description')->nullable();
             $table->enum('privacy', ['public', 'private', 'shared'])->default('private');
             $table->string('image')->nullable();

--- a/database/migrations/2024_09_06_180511_create_playlist_songs_table.php
+++ b/database/migrations/2024_09_06_180511_create_playlist_songs_table.php
@@ -14,7 +14,6 @@ return new class extends Migration
         Schema::create('playlist_songs', function (Blueprint $table) {
             $table->foreignId('playlist_id')->constrained('playlists')->onDelete('cascade');
             $table->foreignId('song_id')->constrained('songs')->onDelete('cascade');
-            $table->date('date_added');
             $table->primary(['playlist_id', 'song_id']);
             $table->boolean('is_active')->default(true);
             $table->timestamps();

--- a/database/migrations/2024_09_06_180512_create_playback_histories_table.php
+++ b/database/migrations/2024_09_06_180512_create_playback_histories_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id();
             $table->foreignUuid('user_id')->constrained('users')->onDelete('cascade');
             $table->foreignId('song_id')->constrained('songs')->onDelete('cascade');
-            $table->timestamp('play_date');
             $table->boolean('is_active')->default(true);
             $table->timestamps();
         });

--- a/database/migrations/2024_09_06_180517_create_comments_table.php
+++ b/database/migrations/2024_09_06_180517_create_comments_table.php
@@ -16,7 +16,6 @@ return new class extends Migration
             $table->foreignUuid('user_id')->constrained('users')->onDelete('cascade');
             $table->foreignId('post_id')->constrained('posts')->onDelete('cascade');
             $table->text('content');
-            $table->timestamp('publication_date');
             $table->boolean('is_active')->default(true);
             $table->timestamps();
         });

--- a/database/migrations/2024_09_08_173051_create_followed_playlists_table.php
+++ b/database/migrations/2024_09_08_173051_create_followed_playlists_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id(); // FollowedPlaylistID (PK)
             $table->foreignUuid('user_id')->constrained('users')->onDelete('cascade'); // UsuarioID (FK)
             $table->foreignId('playlist_id')->constrained('playlists')->onDelete('cascade'); // PlaylistID (FK)
-            $table->date('follow_date'); // FechaSeguimiento
             $table->boolean('is_active')->default(true); // Activo
             $table->timestamps();
         });

--- a/database/seeders/AlbumSeeder.php
+++ b/database/seeders/AlbumSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Album;
+use App\Models\Artist;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class AlbumSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo álbum
+        Album::create([
+            'title' => 'Greatest Hits',
+            'artist_id' => Artist::where('user_id', '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3')->first()->id, // Blessd
+            'release_date' => '2024-09-01',
+            'description' => 'The best songs of all time.',
+            'icon' => 'https://i.scdn.co/image/ab67616d0000b273c164b1a439733e92b5044700',
+        ]);
+    }
+}

--- a/database/seeders/ArtistSeeder.php
+++ b/database/seeders/ArtistSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Artist;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ArtistSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo artista
+        Artist::create([
+            'user_id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3',
+            'verified' => true,
+            'about' => 'Stiven Mesa Londoño, conocido artísticamente como Blessd, es un cantante, compositor colombiano y modelo En octubre de 2021, firmó con Warner Music Latina y lanzó su primer álbum de estudio llamado "Hecho en Medellín". Una de sus canciones fue inspirada en Octavio Mesa.',
+        ]);
+    }
+}

--- a/database/seeders/CommentSeeder.php
+++ b/database/seeders/CommentSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Comment;
+use App\Models\Post;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CommentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo comentario
+        Comment::create([
+            'user_id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3', // Blessd
+            'post_id' => Post::where('user_id', '8f6eea1e-9011-40ec-8ae4-19916127672b')->first()->id, // My first post
+            'content' => 'En la buena papi, gracias por el apoyo.',
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ class DatabaseSeeder extends Seeder
         // Llamar a los seeders
         $this->call([
             UserSeeder::class,
+            ArtistSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        // Llamar a los seeders
+        $this->call([
+            UserSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,6 +30,7 @@ class DatabaseSeeder extends Seeder
             PlaylistSongSeeder::class,
             SharedPlaylistSeeder::class,
             PlaybackHistorySeeder::class,
+            FollowedPlaylistSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             ArtistSeeder::class,
+            AlbumSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Follow;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -21,6 +22,7 @@ class DatabaseSeeder extends Seeder
             SongSeeder::class,
             PostSeeder::class,
             LikeSeeder::class,
+            FollowSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,6 +20,7 @@ class DatabaseSeeder extends Seeder
             AlbumSeeder::class,
             SongSeeder::class,
             PostSeeder::class,
+            LikeSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             ArtistSeeder::class,
             AlbumSeeder::class,
+            SongSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Follow;
+use App\Models\PlaylistSong;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -24,7 +25,9 @@ class DatabaseSeeder extends Seeder
             LikeSeeder::class,
             FollowSeeder::class,
             PlaylistSeeder::class,
+            PlaylistSongSeeder::class,
             SharedPlaylistSeeder::class,
+            PlaybackHistorySeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Comment;
 use App\Models\Follow;
 use App\Models\PlaylistSong;
 use App\Models\User;
@@ -22,6 +23,7 @@ class DatabaseSeeder extends Seeder
             AlbumSeeder::class,
             SongSeeder::class,
             PostSeeder::class,
+            CommentSeeder::class,
             LikeSeeder::class,
             FollowSeeder::class,
             PlaylistSeeder::class,

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,8 @@ class DatabaseSeeder extends Seeder
             PostSeeder::class,
             LikeSeeder::class,
             FollowSeeder::class,
+            PlaylistSeeder::class,
+            SharedPlaylistSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             ArtistSeeder::class,
             AlbumSeeder::class,
             SongSeeder::class,
+            PostSeeder::class,
         ]);
     }
 }

--- a/database/seeders/FollowSeeder.php
+++ b/database/seeders/FollowSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Follow;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class FollowSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo follow
+        Follow::create([
+            'follower_id' => '8f6eea1e-9011-40ec-8ae4-19916127672b', // John Doe
+            'followed_id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3', // Blessd
+        ]);
+    }
+}

--- a/database/seeders/FollowedPlaylistSeeder.php
+++ b/database/seeders/FollowedPlaylistSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\FollowedPlaylist;
+use App\Models\Playlist;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class FollowedPlaylistSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear una nueva playlist seguida
+        FollowedPlaylist::create([
+            'user_id' => '741944d5-4f2e-4533-af0d-1155ededce3a', // Valentina
+            'playlist_id' => Playlist::where('user_id', '8f6eea1e-9011-40ec-8ae4-19916127672b')->first()->id, // Awesome Mix Vol. 1
+        ]);
+    }
+}

--- a/database/seeders/LikeSeeder.php
+++ b/database/seeders/LikeSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Like;
+use App\Models\Post;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class LikeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Like::create([
+            'user_id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3',
+            'post_id' => Post::where('user_id', '8f6eea1e-9011-40ec-8ae4-19916127672b')->first()->id,
+        ]);
+    }
+}

--- a/database/seeders/LikeSeeder.php
+++ b/database/seeders/LikeSeeder.php
@@ -14,6 +14,7 @@ class LikeSeeder extends Seeder
      */
     public function run(): void
     {
+        // Crear un nuevo like
         Like::create([
             'user_id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3',
             'post_id' => Post::where('user_id', '8f6eea1e-9011-40ec-8ae4-19916127672b')->first()->id,

--- a/database/seeders/PlaybackHistorySeeder.php
+++ b/database/seeders/PlaybackHistorySeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Artist;
+use App\Models\PlaybackHistory;
+use App\Models\Song;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PlaybackHistorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo historial de reproducción
+        $artist_id = Artist::where('user_id', '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3')->first()->id; // Blessd
+        PlaybackHistory::create([
+            'user_id' => '8f6eea1e-9011-40ec-8ae4-19916127672b', // John Doe
+            'song_id' => Song::where('artist_id', $artist_id)->first()->id, // Mírame
+        ]);
+    }
+}

--- a/database/seeders/PlaylistSeeder.php
+++ b/database/seeders/PlaylistSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Playlist;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PlaylistSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear una nueva playlist
+        Playlist::create([
+            'name' => 'Awesome Mix Vol. 1',
+            'user_id' => '8f6eea1e-9011-40ec-8ae4-19916127672b', // John Doe
+            'description' => 'A collection of my favorite songs.',
+            'privacy' => 'shared',
+            'image' => 'https://i.ibb.co/zbCwymf/291216a.jpg',
+        ]);
+    }
+}

--- a/database/seeders/PlaylistSongSeeder.php
+++ b/database/seeders/PlaylistSongSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Artist;
+use App\Models\Playlist;
+use App\Models\PlaylistSong;
+use App\Models\Song;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PlaylistSongSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear una nueva canción en una playlist
+        $artist_id = Artist::where('user_id', '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3')->first()->id; // Blessd
+        PlaylistSong::create([
+            'playlist_id' => Playlist::where('user_id', '8f6eea1e-9011-40ec-8ae4-19916127672b')->first()->id, // Awesome Mix Vol. 1
+            'song_id' => Song::where('artist_id', $artist_id)->first()->id, // Mírame
+        ]);
+    }
+}

--- a/database/seeders/PostSeeder.php
+++ b/database/seeders/PostSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Artist;
+use App\Models\Post;
+use App\Models\Song;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PostSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo post
+        $artist_id = Artist::where('user_id', '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3')->first()->id; // Blessd
+        Post::create([
+            'user_id' => '8f6eea1e-9011-40ec-8ae4-19916127672b',
+            'content' => 'This is my favorite song',
+            'image' => 'https://i.ytimg.com/vi/zcw8NlHljF4/maxresdefault.jpg',
+            'song_id' => Song::where('artist_id', $artist_id)->first()->id, // Mírame
+        ]);
+    }
+}

--- a/database/seeders/SharedPlaylistSeeder.php
+++ b/database/seeders/SharedPlaylistSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Playlist;
+use App\Models\SharedPlaylist;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SharedPlaylistSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear una playlist compartida
+        SharedPlaylist::create([
+            'playlist_id' => Playlist::where('user_id', '8f6eea1e-9011-40ec-8ae4-19916127672b')->first()->id, // Awesome Mix Vol. 1
+            'user_id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3', // Blessd
+        ]);
+    }
+}

--- a/database/seeders/SongSeeder.php
+++ b/database/seeders/SongSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Album;
+use App\Models\Artist;
+use App\Models\Song;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SongSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear una nueva canción
+        $artist_id = Artist::where('user_id', '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3')->first()->id; // Blessd
+        Song::create([
+            'title' => 'Mírame',
+            'artist_id' => $artist_id,
+            'album_id' => Album::where('artist_id', $artist_id)->first()->id, // Greatest Hits
+            'time' => '00:01:38', // hh:mm:ss
+            'genre' => 'Reggaeton',
+            'url_song' => 'https://i.scdn.co/image/ab67616d0000b273b62a2ec2d61d48f34a368144',
+        ]);
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Crear un nuevo usuario
+        User::create([
+            'id' => '8f6eea1e-9011-40ec-8ae4-19916127672b',
+            'username' => 'John Doe',
+            'birthday' => '1995-01-01',
+            'country' => 'United States',
+            'email' => 'john.doe@gmail.com',
+            'password' => Hash::make('12345678'),
+            'description' => 'Hello, I am John Doe',
+            'profile_picture' => 'https://i.pinimg.com/280x280_RS/ec/16/b8/ec16b8e8e09a99a2b8fff167dbf53c11.jpg',
+            'profile_banner' => 'https://tinkercademy.com/wp-content/uploads/2017/04/Generic-Banner-07-Web-App-Developer.png',
+        ]);
+
+        // Crear un nuevo artista
+        User::create([
+            'id' => '264e1f6c-52ec-48ea-bfb1-13100f8b5cf3',
+            'username' => 'Blessd',
+            'birthday' => '2000-01-27',
+            'country' => 'Colombia',
+            'email' => 'blessd@gmail.com',
+            'password' => Hash::make('12345678'),
+            'role' => 'artist',
+            'description' => 'Hecho en Medellín',
+            'profile_picture' => 'https://i.scdn.co/image/ab676161000051741b5902b400971bc07d3473dd',
+            'profile_banner' => 'https://www.infobae.com/resizer/v2/ARBKXYU6NRDZZCFBAUUGBAK4QY.jpg?auth=7dbd6d124f15e1558eb1bc52d6094b6a07fc831848047c1bf1c29d09ea7f550a&smart=true&width=1200&height=675&quality=85',
+        ]);
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -40,5 +40,30 @@ class UserSeeder extends Seeder
             'profile_picture' => 'https://i.scdn.co/image/ab676161000051741b5902b400971bc07d3473dd',
             'profile_banner' => 'https://www.infobae.com/resizer/v2/ARBKXYU6NRDZZCFBAUUGBAK4QY.jpg?auth=7dbd6d124f15e1558eb1bc52d6094b6a07fc831848047c1bf1c29d09ea7f550a&smart=true&width=1200&height=675&quality=85',
         ]);
+
+        // Crear un nuevo usuario
+        User::create([
+            'id' => '741944d5-4f2e-4533-af0d-1155ededce3a',
+            'username' => 'Valentina',
+            'birthday' => '2001-01-01',
+            'country' => 'Colombia',
+            'email' => 'valentina@gmail.com',
+            'password' => Hash::make('12345678'),
+            'description' => 'Hello, I am Valentina',
+            'profile_picture' => 'https://i.ibb.co/HCR6qqF/a.png',
+            'profile_banner' => 'https://tinkercademy.com/wp-content/uploads/2017/04/Generic-Banner-07-Web-App-Developer.png',
+        ]);
+
+        // Crear un nuevo administrador
+        User::create([
+            'id' => '9c87a67f-e553-4e5f-8c7b-dcbd8c39c27a',
+            'username' => 'Admin',
+            'birthday' => '1990-01-01',
+            'country' => 'United States',
+            'email' => 'admin@gmail.com',
+            'password' => Hash::make('12345678'),
+            'role' => 'admin',
+            'description' => 'Hello, I am Admin',
+        ]);
     }
 }


### PR DESCRIPTION
This pull request adds seeders for various models to populate the database with default data. The UserSeeder creates two default users, the ArtistSeeder creates a default artist, the AlbumSeeder creates a default album, the SongSeeder creates a default song, the PostSeeder creates a default post, the LikeSeeder creates a default like, the PlaylistSeeder creates a default playlist, the PlaylistSongSeeder adds a song to a playlist, the PlaybackHistorySeeder creates a playback history entry, the CommentSeeder creates a comment on a post, and the FollowedPlaylistSeeder creates a followed playlist. These seeders are useful for testing and populating the database with initial data. Additionally, some model fields have been removed to simplify the data structure and improve code readability.